### PR TITLE
Cross-building enabled for different Scala versions (well, almost :-))

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,26 @@
 
 	<profiles>
 		<profile>
+			<id>scala-2.9.0</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<scala.version>2.9.0</scala.version>
+			</properties>
+		</profile>
+		<profile>
+			<id>scala-2.10.1</id>
+			<activation>
+				<property>
+					<name>scala-2.10.1</name>
+				</property>
+			</activation>
+			<properties>
+				<scala.version>2.10.1</scala.version>
+			</properties>
+		</profile>
+		<profile>
 			<!--
 				This profile uses the proguard plugin to reduce the size of the
 				output jar. It is usefull when combined with nodeps profile which
@@ -237,6 +257,14 @@
 						<exclude>org/graphstream/ui/j2dviewer/renderer/test/**</exclude>
 					</excludes>
 				</configuration>
+				<executions>
+					<execution>
+						<id>default-jar</id>
+						<configuration>
+							<classifier>${scala.version}</classifier>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>
@@ -290,7 +318,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<scalaVersion>2.9</scalaVersion>
+					<scalaVersion>${scala.version}</scalaVersion>
 				</configuration>
 			</plugin>
 
@@ -334,7 +362,7 @@
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
-			<version>2.9.0</version>
+			<version>${scala.version}</version>
 			<optional>false</optional>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
I'm not sure how useful this is but I was in the need of it so thought it may worth a pull request.

So the issue is that I had a binary compatibility issue: tried to run the `TestStars2` demo with Scala 2.10. The loading of `AttributeUtils` died because of the missing `ClassManifest` class (that has been marked as deprecated before and removed from the 2.10 build). It turned out you also use Scala in the code :-)

So here's a proposal: so far the Scala version was not included in the build proces of the _gs-ui_ project, which is common in Scala projects (take a look on the builds of [Specs2](http://oss.sonatype.org/content/repositories/releases/org/specs2/) and [ScalaTest](https://oss.sonatype.org/content/repositories/releases/org/scalatest/) for example).

I'm not too familiar with your building/publishing process, but I made a few minor additions to the project's POM.

This way you can build against Scala 2.9 (as it was previously to maintain compatibility) with the usual:

```
mvn clean package
```

command. On the other hand, you can also specify a profile to build against Scala 2.10 like:

```
mvn -P scala-2.10.1 clean package
```

for instance.

The drawback is that I wasn't able to find a way with Maven to build it similarly to other projects, namely, to include the Scala version number in the `artifactId`. My problem is that I don't like having a property reference in the `artifactId` element, it may confuse some additional tools (e.g., installing into the local repo may confuse Sbt/Ivy, because it would resolve the variable to its default value, so it might complain against invalid group references and so on).

So my solution was to use classifiers as it was suggested in several places.

This way the user may use a given version of `gs-ui` with:

```
<dependency>
    <groupId>org.graphstream</groupId>
    <artifactId>gs-ui</artifactId>
    <version>1.2-SNAPSHOT</version>
    <classifier>2.9.0</classifier> <!-- or 2.10.1, or .... -->
</dependency>
```

Or the same with Sbt:

```
libraryDependencies ++= Seq(
    "org.graphstream" %  "gs-ui" % "1.2-SNAPSHOT" classifier "2.10.1"
)
```

Unfortunately the `%%` operator cannot be used (since the Scala version is included in the artifact id), and the `classifier "2.10.1"` postfix is required, which is quite non-standard, but I wasn't able to find any better solution for this issue.

So that was my local hack to the issue, but I would be really interested in hearing your opinion about it.

Cheers,
Richard
