### PR TITLE
Fix for Issue #80, "Click on nodes in the GUI is not accurate in some circumstances." 

### DIFF
--- a/src-scala/org/graphstream/ui/j2dviewer/Camera.scala
+++ b/src-scala/org/graphstream/ui/j2dviewer/Camera.scala
@@ -3,7 +3,7 @@
  *     Stefan Balev     <stefan.balev@graphstream-project.org>
  *     Julien Baudry    <julien.baudry@graphstream-project.org>
  *     Antoine Dutot    <antoine.dutot@graphstream-project.org>
- *     Yoann Pign��      <yoann.pigne@graphstream-project.org>
+ *     Yoann Pigné      <yoann.pigne@graphstream-project.org>
  *     Guilhelm Savin   <guilhelm.savin@graphstream-project.org>
  * 
  * This file is part of GraphStream <http://graphstream-project.org>.

--- a/src-scala/org/graphstream/ui/j2dviewer/J2DGraphRenderer.scala
+++ b/src-scala/org/graphstream/ui/j2dviewer/J2DGraphRenderer.scala
@@ -3,7 +3,7 @@
  *     Stefan Balev     <stefan.balev@graphstream-project.org>
  *     Julien Baudry    <julien.baudry@graphstream-project.org>
  *     Antoine Dutot    <antoine.dutot@graphstream-project.org>
- *     Yoann Pign��      <yoann.pigne@graphstream-project.org>
+ *     Yoann Pigné      <yoann.pigne@graphstream-project.org>
  *     Guilhelm Savin   <guilhelm.savin@graphstream-project.org>
  * 
  * This file is part of GraphStream <http://graphstream-project.org>.


### PR DESCRIPTION
DefaultView only works if it is in the top left corner of the parent frame.

Code was incorrectly adjusting for the top left corner of the DefaultView as if the coordinates were absolute.  However, when the DefaultMouseManger does a lookup to see which element is at the mouse coordinate it uses the View/JPanel's relative mouse click coordinates.
