### PR TITLE
Minor fix to a link in the README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -3,7 +3,7 @@ GraphStream
 
 Welcome to GraphStream, and thank you for your download, we hope you will find it useful and practical.
 
-We are always interested by suggestions on how to make the library more developer friendly, see the [website](www.graphstream-project.org) for more information.
+We are always interested by suggestions on how to make the library more developer friendly, see the [website](http://graphstream-project.org) for more information.
 
 UI
 --


### PR DESCRIPTION
I was just starting to look into this project (and haven't even used it yet), but hit a simple problem in the README.  Without the URL protocol, it was treating it as a relative link and sending people here:
https://github.com/graphstream/gs-ui/blob/master/www.graphstream-project.org
