### PR TITLE
Fixed Exception when viewport size is exactly equal to padding.

### DIFF
--- a/src-scala/org/graphstream/ui/j2dviewer/Camera.scala
+++ b/src-scala/org/graphstream/ui/j2dviewer/Camera.scala
@@ -297,8 +297,8 @@ class Camera(protected val graph:GraphicGraph) extends org.graphstream.ui.swingV
   		var padXpx = paddingXpx * 2
   		var padYpx = paddingYpx * 2
 
-		if(padXpx > metrics.viewport(2)) padXpx = metrics.viewport(2) / 10.0
-		if(padYpx > metrics.viewport(3)) padYpx = metrics.viewport(3) / 10.0
+		if(padXpx >= metrics.viewport(2)) padXpx = metrics.viewport(2) / 10.0
+		if(padYpx >= metrics.viewport(3)) padYpx = metrics.viewport(3) / 10.0
 
   		sx = (metrics.viewport(2) - padXpx) / (metrics.size.data(0) + padXgu)	// Ratio along X
   		sy = (metrics.viewport(3) - padYpx) / (metrics.size.data(1) + padYgu)	// Ratio along Y
@@ -343,8 +343,8 @@ class Camera(protected val graph:GraphicGraph) extends org.graphstream.ui.swingV
   		val gw     = if(gviewport ne null) gviewport(2)-gviewport(0) else metrics.size.data(0)
   		val gh     = if(gviewport ne null) gviewport(3)-gviewport(1) else metrics.size.data(1)
 
-		if(padXpx > metrics.viewport(2)) padXpx = metrics.viewport(2) / 10.0
-		if(padYpx > metrics.viewport(3)) padYpx = metrics.viewport(3) / 10.0
+		if(padXpx >= metrics.viewport(2)) padXpx = metrics.viewport(2) / 10.0
+		if(padYpx >= metrics.viewport(3)) padYpx = metrics.viewport(3) / 10.0
 		
   		sx = (metrics.viewport(2) - padXpx) / ((gw + padXgu) * zoom) 
 		sy = (metrics.viewport(3) - padYpx) / ((gh + padYgu) * zoom)


### PR DESCRIPTION
This should fix issue #100.

The problem here is, that when the viewport size is exactly equal to the overall padding sx and/or sy are computed to zero and the resulting AffineTransform in the Backend will become uninvertable.
